### PR TITLE
Fix contains, startsWith, and endsWith disabled operators assertion

### DIFF
--- a/src/query.pegjs
+++ b/src/query.pegjs
@@ -96,33 +96,33 @@ Regex
 
 StartsWith
   = "startsWith(" __ prop:Property __ "," __ value:Scalar __ ")" {
-    assertCan('StartsWith');
+    assertCan('startsWith');
     return set({}, prop, {$regex: '^' + escapeRegex(value)});
   }
   / "not(startsWith(" __ prop:Property __ "," __ value:Scalar __ "))" {
-    assertCan('StartsWith');
+    assertCan('startsWith');
     assertCan('not');
     return set({}, prop, {$not: new RegExp('^' + escapeRegex(value))});
   }
 
 EndsWith
   = "endsWith(" __ prop:Property __ "," __ value:Scalar __ ")" {
-    assertCan('EndsWith');
+    assertCan('endsWith');
     return set({}, prop, {$regex: escapeRegex(value) + '$'});
   }
   / "not(endsWith(" __ prop:Property __ "," __ value:Scalar __ "))" {
-    assertCan('EndsWith');
+    assertCan('endsWith');
     assertCan('not');
     return set({}, prop, {$not: new RegExp(escapeRegex(value) + '$')});
   }
 
 Contains
   = "contains(" __ prop:Property __ "," __ value:Scalar __ ")" {
-    assertCan('Contains');
+    assertCan('contains');
     return set({}, prop, {$regex: escapeRegex(value)});
   }
   / "not(contains(" __ prop:Property __ "," __ value:Scalar __ "))" {
-    assertCan('Contains');
+    assertCan('contains');
     assertCan('not');
     return set({}, prop, {$not: new RegExp(escapeRegex(value))});
   }

--- a/test/query.js
+++ b/test/query.js
@@ -97,6 +97,12 @@ describe('query', function() {
           .to.throw('regex operator is disabled');
         expect(query.bind(null, 'eq(tags,"nodejs")', {disabledOperators:['eq']}))
           .to.throw('eq operator is disabled');
+        expect(query.bind(null, 'contains(tags,"nodejs")', {disabledOperators:['contains']}))
+          .to.throw('contains operator is disabled');
+        expect(query.bind(null, 'startsWith(tags,"nodejs")', {disabledOperators:['startsWith']}))
+          .to.throw('startsWith operator is disabled');
+        expect(query.bind(null, 'endsWith(tags,"nodejs")', {disabledOperators:['endsWith']}))
+          .to.throw('endsWith operator is disabled');
       });
     });
   });


### PR DESCRIPTION
Hi @seangarner 

For contains, startsWith, and endsWith, the query parser's `assertCan` function is being called with a proper cased version of the disablement string. As such, these operators could not be disabled.

I've fixed this issue and added a couple of tests. The tests' value is questionable as there are other operators which pass a literal to the `assertCan` function, so feel free to cherry pick.
