### PR TITLE
add elemMatch projection operator support to fields parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,20 @@ time you can mix `-` and `+`.
 GET /people?fields=-_id,+firstName,+address.country
 ```
 
+The following projection operators are also supported:
+
+operator               | example
+---------------------- | ----------------------------------
+[elemMatch-projection] | `elemMatch(students,eq(school,102))`
+
+Projection operators can be mixed with projection parameters, however it's difficult to prevent
+mixed exclusive and exclusive parameters with operators so it's recommended that operators come last
+in the fields string.  e.g.
+
+```
+GET /courses?fields=-id,+title,elemMatch(students,eq(gender,"female"))
+```
+
 ### `limit`
 Limit how many documents are returned.
 
@@ -252,5 +266,6 @@ mongoUrlUtils('fields=+id,-_id', options); // throws an Error
 mongoUrlUtils('fields=%2Bid,-_id', options); // works as expected
 ```
 
+[elemMatch-projection]: https://docs.mongodb.org/manual/reference/operator/projection/elemMatch/
 [mdn-date]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date
 [ecma-datetime]: http://www.ecma-international.org/ecma-262/5.1/#sec-15.9.1.15

--- a/src/fields.pegjs
+++ b/src/fields.pegjs
@@ -1,3 +1,10 @@
+{
+  function set(o, p, v) {
+    o[p] = v;
+    return o;
+  }
+}
+
 start
   = fields
 
@@ -24,6 +31,7 @@ fields
 including
   = "+" right:field { return [right, 1]; }
   / "-_id" { return ['_id', 0]; }
+  / ElemMatchProjection
   / " " right:field {
     if (options.strictEncoding === true) throw new Error('Expected "+" or "-"; disable strictEncoding to allow space in place of +');
     return [right, 1];
@@ -31,6 +39,275 @@ including
 
 excluding
   = "-" right:field { return [right, 0]; }
+  / ElemMatchProjection
 
 field
   = field:$([^\.$,\0][^,\0]*) { return field; }
+
+ElemMatchProjection
+  = "elemMatch(" field:field "," query:Query ")" {
+    return [field, {$elemMatch: query}];
+  }
+
+Query
+  = ScalarComparison
+  / LogicalComparison
+  / ArrayComparison
+  / Exists
+  / ElemMatch
+  / Regex
+  / Mod
+  / Where
+  / Type
+
+ScalarComparisonOperator
+  = "eq"
+  / "ne"
+  / "gte"
+  / "gt"
+  / "lte"
+  / "lt"
+  / "ne"
+  / "size"
+
+ArrayComparisonOperator
+  = "in"
+  / "nin"
+  / "all"
+
+LogicalComparisonOperator
+  = "and"
+  / "or"
+
+LogicalComparison
+  = op:$LogicalComparisonOperator "(" __ head:Query __ tail:("," __ Query)* ")" {
+    return set({}, '$' + op, collect(head, tail));
+  }
+
+ScalarComparison
+  = op:$ScalarComparisonOperator "(" __ prop:Property __ "," __ value:Scalar __ ")" {
+    var child = set({}, '$' + op, value);
+    return set({}, prop, child);
+  }
+
+ArrayComparison
+  = op:$ArrayComparisonOperator "(" __ prop:Property __ "," __ values:Array __ ")" {
+    var child = set({}, '$' + op, values);
+    return set({}, prop, child);
+  }
+
+Regex
+  = "regex(" __ prop:Property __ "," __ pattern:String __ opts:("," __ [imxs]+ __)? ")" {
+    if (opts) return set({}, prop, {$regex: pattern, $options: opts[2].join('')});
+    return set({}, prop, {$regex: pattern});
+  }
+
+Where
+  = "where(" __ expression:String __ ")" {
+    return {$where: expression};
+  }
+
+Mod
+  = "mod(" __ prop:Property __ "," __ divisor:Number __ "," __ remainder:Number __ ")" {
+    return set({}, prop, { $mod: [divisor, remainder] });
+  }
+
+ElemMatch
+  = "elemMatch(" __ prop:Property __ "," __ head:Query __ tail:("," __ Query)* ")" {
+    return set({}, prop, {$elemMatch: {$and: collect(head, tail)}});
+  }
+
+Exists
+  = "exists(" __ prop:Property __ "," __ value:Boolean __ ")" {
+    return set({}, prop, {$exists: value});
+  }
+
+Type
+  = "type(" __ prop:Property __ "," __ id:MongoType __ ")" {
+    var typeMap = {
+      Double: 1,
+      String: 2,
+      Object: 3,
+      Array: 4,
+      Binary:	5,
+      Undefined: 6,
+      ObjectId: 7,
+      Boolean:	8,
+      Date: 9,
+      Null: 10,
+      RegExp: 11,
+      Javascript:	13,
+      Symbol:	14,
+      ScopedJavascript:	15,
+      Int32: 16,
+      Timestamp: 17,
+      Int64: 18
+    };
+    if (typeof id === 'string') id = typeMap[id];
+    if (id < -1 || id > 254) throw new Error('Expected number between -1 and 254');
+    return set({}, prop, {$type: id});
+  }
+
+
+MongoType
+  = ParsedInt
+  / "Double"
+  / "String"
+  / "ObjectId"
+  / "Object"
+  / "Array"
+  / "Binary"
+  / "Undefined"	// Deprecated
+  / "Boolean"
+  / "Date"
+  / "Null"
+  / "RegExp"
+  / "Javascript"
+  / "Symbol"
+  / "ScopedJavascript"
+  / "Int32"
+  / "Timestamp"
+  / "Int64"
+
+//TODO: make this completely mongo compatible
+Property "document property"
+  = property:$([^\.$,\0\ ][^,\0\ ]*) { return property; }
+
+Scalar "scalar value"
+  = String
+  / Number
+  / Boolean
+  / Date
+  / "null" __  { return null;  }
+
+Boolean "boolean"
+  = "true"  __ { return true; }
+  / "false" __ { return false; }
+
+Array "array"
+  = "[" __ "]" __                   { return [];       }
+  / "[" __ elements:Elements "]" __ { return elements; }
+
+Elements "elements"
+  = head:Scalar tail:("," __ Scalar)* {
+      return collect(head, tail);
+    }
+
+String "string"
+  = '"' '"' __             { return "";    }
+  / '"' chars:Chars '"' __ { return chars; }
+
+Chars "chars"
+  = chars:Char+ { return chars.join(""); }
+
+Char "char"
+  = [^"\\\0-\x1F\x7f]
+  / '\\"'  { return '"';  }
+  / "\\\\" { return "\\"; }
+  / "\\/"  { return "/";  }
+  / "\\b"  { return "\b"; }
+  / "\\f"  { return "\f"; }
+  / "\\n"  { return "\n"; }
+  / "\\r"  { return "\r"; }
+  / "\\t"  { return "\t"; }
+  / "\\u" digits:$(HexDigit HexDigit HexDigit HexDigit) {
+      return String.fromCharCode(parseInt(digits, 16));
+    }
+
+Number "number"
+  = parts:$(Int Frac Exp) __ { return parseFloat(parts); }
+  / parts:$(Int Frac) __     { return parseFloat(parts); }
+  / parts:$(Int Exp) __      { return parseFloat(parts); }
+  / parts:$(Int) __          { return parseFloat(parts); }
+
+Int "integer"
+  = Digit19 Digits
+  / Digit
+  / "-" Digit19 Digits
+  / "-" Digit
+
+Date "date"
+  = "Date(" dateTimeStr:$(EcmaDateTime) ")" {
+      var date = new Date(dateTimeStr);
+      assertDateIsValid(date, dateTimeStr);
+      return date;
+    }
+
+ParsedInt "integer"
+  = n:$(Int) {
+    return parseInt(n, 10);
+  }
+
+Frac "fraction"
+  = "." Digits
+
+Exp
+  = E Digits
+
+Digits "digits"
+  = Digit+
+
+E "exponent"
+  = [eE] [+-]?
+
+Digit "digit"
+  = [0-9]
+
+Digit19 "non-zero digit"
+  = [1-9]
+
+HexDigit "hex digit"
+  = [0-9a-fA-F]
+
+__ "whitespace"
+  = Whitespace*
+
+Whitespace
+  = " "
+
+/*
+  The following productions parse valid and invalid ECMAScript date time strings.
+
+  ECMAScript 5.1 implements a date time string format that is a simplification of the ISO 8601
+  Extended Format.
+
+  See http://www.ecma-international.org/ecma-262/5.1/#sec-15.9.1.15 for more information on this
+  specification.
+ */
+EcmaDateTime "date time"
+  = EcmaDate "T" EcmaTime EcmaTimeZoneOffset?
+  / EcmaDate EcmaZuluTimeZone?
+
+EcmaTime "time"
+  = EcmaTimeHours ":" EcmaTimeMinutes (":" EcmaTimeSeconds ("." EcmaTimeMilliseconds)?)?
+
+EcmaTimeHours "hours"
+  = Digit Digit
+
+EcmaTimeMinutes "minutes"
+  = Digit Digit
+
+EcmaTimeSeconds "seconds"
+  = Digit Digit
+
+EcmaTimeMilliseconds "milliseconds"
+  = Digit Digit Digit
+
+EcmaZuluTimeZone "zulu timezone"
+  = "Z"
+
+EcmaTimeZoneOffset "timezone offset"
+  = EcmaZuluTimeZone
+  / [+-] EcmaTimeHours ":" EcmaTimeMinutes
+
+EcmaDate "date"
+  = EcmaDateYear ("-" EcmaDateMonth ("-" EcmaDateDay)?)?
+
+EcmaDateYear "year"
+  = Digit Digit Digit Digit
+
+EcmaDateMonth "month"
+  = Digit Digit
+
+EcmaDateDay "day"
+  = Digit Digit

--- a/test/fields.js
+++ b/test/fields.js
@@ -73,4 +73,59 @@ describe('fields', function() {
     expect(mongoUrl.fields.bind(null, ' include', {strictEncoding: true})).to.throw('Expected "+" or "-"; disable strictEncoding to allow space in place of +');
   });
 
+  it('should recognise an elemMatch query', function () {
+    expect(mongoUrl.fields('elemMatch(students,eq(school,102))')).to.eql({
+      students:{
+        $elemMatch:{
+          school:{
+            $eq:102
+          }
+        }
+      }
+    });
+  });
+
+  it('should mix elemMatch and inclusive projection', function () {
+    var expected = {
+      name: 1,
+      students:{
+        $elemMatch:{
+          school:{
+            $eq:102
+          }
+        }
+      }
+    };
+    expect(mongoUrl.fields('+name,elemMatch(students,eq(school,102))')).to.eql(expected);
+    expect(mongoUrl.fields('elemMatch(students,eq(school,102)),+name')).to.eql(expected);
+  });
+
+  it('should mix elemMatch and exclusive projection', function () {
+    var expected = {
+      name: 0,
+      students:{
+        $elemMatch:{
+          school:{
+            $eq:102
+          }
+        }
+      }
+    };
+    expect(mongoUrl.fields('-name,elemMatch(students,eq(school,102))')).to.eql(expected);
+  });
+
+  it.skip('should mix elemMatch and exclusive projection when elemMatch is first', function () {
+    var expected = {
+      name: 0,
+      students:{
+        $elemMatch:{
+          school:{
+            $eq:102
+          }
+        }
+      }
+    };
+    expect(mongoUrl.fields('elemMatch(students,eq(school,102)),-name')).to.eql(expected);
+  });
+
 });


### PR DESCRIPTION
Solution should leave the door open for other projection operators (e.g. `$`, `$slice`).
